### PR TITLE
Change to our own argparsing

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,10 @@
-use std::{
-    collections::HashMap,
-    ffi::{OsStr, OsString},
-    path::PathBuf,
-};
+use std::{ffi::OsString, path::PathBuf};
 
+const COMPRESS_SUBCOMMAND_FLAGS: [(&str, &str); 1] = [("-o", "--output")];
+const DECOMPRESS_SUBCOMMAND_FLAGS: [(&str, &str); 0] = [];
+const SUBCOMMNADS: [&str; 1] = ["compress"];
+
+#[derive(Debug, PartialEq)]
 pub enum Command {
     Compress {
         files: Vec<PathBuf>,
@@ -15,113 +16,411 @@ pub enum Command {
     // Convert,
     ShowHelp,
     ShowVersion,
-    UnknownFlags(Vec<OsString>),
 }
 
-pub struct Flag {
-    short: OsString,
-    long: OsString,
+#[derive(Debug, PartialEq)]
+pub enum ArgParsingError {
+    InvalidFlags(Vec<OsString>),
 }
 
-impl Flag {
-    pub fn new(short: impl Into<OsString>, long: impl Into<OsString>) -> Self {
-        Flag {
-            short: short.into(),
-            long: long.into(),
+pub mod argparsing {
+    use std::{
+        collections::HashMap,
+        ffi::{OsStr, OsString},
+        path::PathBuf,
+    };
+
+    // struct Opt {
+    //     /// Activate debug mode
+    //     // short and long flags (-d, --debug) will be deduced from the field's name
+    //     // #[structopt(short, long)]
+    //     debug: bool,
+
+    //     /// Set speed
+    //     // we don't want to name it "speed", need to look smart
+    //     // #[structopt(short = "v", long = "velocity", default_value = "42")]
+    //     speed: f64,
+
+    //     /// Input file
+    //     // #[structopt(parse(from_os_str))]
+    //     input: PathBuf,
+
+    //     /// Output file, stdout if not present
+    //     // #[structopt(parse(from_os_str))]
+    //     output: Option<PathBuf>,
+
+    //     /// Where to write the output: to `stdout` or `file`
+    //     // #[structopt(short)]
+    //     out_type: String,
+
+    //     /// File name: only required when `out-type` is set to `file`
+    //     // #[structopt(name = "FILE", required_if("out-type", "file"))]
+    //     file_name: Option<String>,
+    // }
+
+    struct NotVerifiedParsedArgs {
+        args: Vec<OsString>,
+        short_flags: HashMap<OsString, OsString>,
+        long_flags: HashMap<OsString, OsString>,
+    }
+
+    pub enum IsFlagVariant {
+        No,
+        Short,
+        Long,
+    }
+
+    pub fn is_flag(text: impl AsRef<OsStr>) -> IsFlagVariant {
+        let text = text.as_ref();
+
+        #[cfg(target_family = "unix")]
+        {
+            use std::os::unix::ffi::OsStrExt;
+
+            let bytes = text.as_bytes();
+
+            debug_assert_eq!('-'.len_utf8(), 1);
+            debug_assert_eq!(OsStr::new("--flag").as_bytes().get(0), Some(&b'-'));
+
+            if let Some(b'-') = bytes.get(0) {
+                if let Some(b'-') = bytes.get(1) {
+                    IsFlagVariant::Long
+                } else {
+                    IsFlagVariant::Short
+                }
+            } else {
+                IsFlagVariant::No
+            }
         }
+        #[cfg(target_family = "windows")]
+        {
+            use std::os::windows::ffi::OsStrExt;
+
+            let iter = text.encode_wide();
+
+            // Note that hyphen_in_utf16 == 45_u16
+            if let Some(45_u16) = iter.next() {
+                if let Some(45_u16) = iter.next() {
+                    IsFlagVariant::Long
+                } else {
+                    IsFlagVariant::Short
+                }
+            } else {
+                IsFlagVariant::No
+            }
+        }
+    }
+
+    impl NotVerifiedParsedArgs {
+        pub fn from_args(args: Vec<OsString>) -> Self {
+            // let mut new_args = vec![];
+
+            // let mut i = 0;
+            // // If window[0] is flag, record into hashmap
+            // while let Some(window) = args[i..].windows(2).next() {
+            //     // If is a flag
+            //     // TODO: change types with generic to simplify this if without needs of casting
+            //     if let Some(index) = acceptable_positional_flags
+            //         .iter()
+            //         .position(|&(short, long)| *short == window[0] || *long == window[0])
+            //     {
+            //         let flag = &acceptable_positional_flags.get(index).expect("what?").1;
+            //         // let flag = &acceptable_positional_flags[index].1;
+            //         // If the flag was already passed
+            //         if positional_flags.contains_key(OsStr::new(flag)) {
+            //             panic!("duplicated flag, should this throw an error or just overwrite?");
+            //         }
+
+            //         // Register the flag
+            //         positional_flags.insert(flag.into(), window[1].clone());
+            //         i += 2;
+            //     } else {
+            //         // Isn't flag, so add to new_args
+            //         new_args.push(window[0].clone());
+            //         i += 1;
+            //     }
+            // }
+
+            // if let Some(last) = args.last() {
+            //     if acceptable_positional_flags
+            //         .iter()
+            //         .find(|&(short, long)| *short == last || *long == last)
+            //         .is_some()
+            //     {
+            //         panic!("Flag requires positional argument, at last, no arguments were given...");
+            //     }
+            // }
+
+            // if let Some(last_window) = args.rchunks(2).next() {
+            //     if acceptable_positional_flags
+            //         .iter()
+            //         .find(|&(short, long)| *short == last_window[0] || *long == last_window[0])
+            //         .is_none()
+            //     {
+            //         new_args.push(args.last().unwrap().clone());
+            //     }
+            // }
+
+            // (new_args, positional_flags)
+            todo!();
+        }
+    }
+
+    // Says if any text matches any arg
+    pub fn matches_any_arg(args: &[OsString], texts: &[&str]) -> bool {
+        texts
+            .iter()
+            .any(|text| args.iter().find(|&arg| arg == text).is_some())
+    }
+
+    pub fn pop_subcommand(args: &mut Vec<OsString>, subcommands: &[&str]) -> Option<OsString> {
+        if args.is_empty() {
+            return None;
+        }
+
+        for subcommand in subcommands {
+            if subcommand == &args[0] {
+                let result = args.remove(0);
+                return Some(result);
+            }
+        }
+        None
+    }
+
+    pub fn filter_flags(
+        args: Vec<OsString>,
+        acceptable_positional_flags: &[(&str, &str)],
+    ) -> (Vec<OsString>, HashMap<OsString, OsString>) {
+        // let mut positional_flags = HashMap::<OsString, OsString>::new();
+
+        // let mut new_args = vec![];
+
+        // let mut i = 0;
+        // // If window[0] is flag, record into hashmap
+        // while let Some(window) = args[i..].windows(2).next() {
+        //     // If is a flag
+        //     // TODO: change types with generic to simplify this if without needs of casting
+        //     if let Some(index) = acceptable_positional_flags
+        //         .iter()
+        //         .position(|&(short, long)| *short == window[0] || *long == window[0])
+        //     {
+        //         let flag = &acceptable_positional_flags.get(index).expect("what?").1;
+        //         // let flag = &acceptable_positional_flags[index].1;
+        //         // If the flag was already passed
+        //         if positional_flags.contains_key(OsStr::new(flag)) {
+        //             panic!("duplicated flag, should this throw an error or just overwrite?");
+        //         }
+
+        //         // Register the flag
+        //         positional_flags.insert(flag.into(), window[1].clone());
+        //         i += 2;
+        //     } else {
+        //         // Isn't flag, so add to new_args
+        //         new_args.push(window[0].clone());
+        //         i += 1;
+        //     }
+        // }
+
+        // if let Some(last) = args.last() {
+        //     if acceptable_positional_flags
+        //         .iter()
+        //         .find(|&(short, long)| *short == last || *long == last)
+        //         .is_some()
+        //     {
+        //         panic!("Flag requires positional argument, at last, no arguments were given...");
+        //     }
+        // }
+
+        // if let Some(last_window) = args.rchunks(2).next() {
+        //     if acceptable_positional_flags
+        //         .iter()
+        //         .find(|&(short, long)| *short == last_window[0] || *long == last_window[0])
+        //         .is_none()
+        //     {
+        //         new_args.push(args.last().unwrap().clone());
+        //     }
+        // }
+
+        // (new_args, positional_flags)
+        todo!();
     }
 }
 
-pub fn filter_flags(
-    args: Vec<OsString>,
-    _boolean_flags: Vec<Flag>,
-    positional_flags: Vec<Flag>,
-) -> (Vec<OsString>, HashMap<OsString, OsString>) {
-    //
-    todo!()
+pub fn try_arg_parsing<I, T>(iter: I) -> Result<Command, ArgParsingError>
+where
+    T: Into<OsString>,
+    I: IntoIterator<Item = T>,
+{
+    let mut args: Vec<OsString> = iter.into_iter().skip(1).map(Into::into).collect();
+
+    if argparsing::matches_any_arg(&args, &["--help", "-h"]) || args.is_empty() {
+        return Ok(Command::ShowHelp);
+    }
+
+    if argparsing::matches_any_arg(&args, &["--version", "-v"]) {
+        return Ok(Command::ShowVersion);
+    }
+
+    match argparsing::pop_subcommand(&mut args, &SUBCOMMNADS) {
+        Some(inner) if inner == "compress" => {
+            let (args, positional_flags) =
+                argparsing::filter_flags(args, &COMPRESS_SUBCOMMAND_FLAGS);
+
+            let output_flag = OsString::from("--output");
+            let output_flag = positional_flags
+                .get(&output_flag)
+                .clone()
+                .map(PathBuf::from);
+
+            return Ok(Command::Compress {
+                files: args.into_iter().map(PathBuf::from).collect(),
+                output_folder: output_flag,
+            });
+        }
+        // Defaults to decompress subcommand
+        None => {
+            let (args, positional_flags) =
+                argparsing::filter_flags(args, &DECOMPRESS_SUBCOMMAND_FLAGS);
+
+            return Ok(Command::Decompress {
+                files: args.into_iter().map(PathBuf::from).collect(),
+            });
+        }
+        _ => unreachable!(),
+    }
+
+    // } else {
+    //     if args.contains(&OsString::from("--output")) {
+    //         // Shouldn't be in here, this flag is only for the compress command
+    //         // return Command::UnexpectedFlag
+    //         // TODO: this is bad, fix it
+    //         return Err(ArgParsingError::InvalidFlags(vec!["--output".into()]));
+    //     }
+
+    //     let files = args.into_iter().map(PathBuf::from).collect();
+    //     Ok(Command::Decompress { files })
+    // }
+
+    // let subcommands = ["decompress", "convert"];
+    // let subcommand_detected = subcommands
+    //     .iter()
+    //     .find(|&subcommand| subcommand == first)
+    //     .is_some();
+
+    // // If there is no subcommand, defaults to subcommand "decompress"
+    // if !subcommand_detected {
+    //     args.insert(1, OsString::from("decompress"));
+    // }
 }
 
-impl Command {
-    pub fn from<I, T>(iter: I) -> Self
-    where
-        T: Into<OsString>,
-        I: IntoIterator<Item = T>,
-    {
-        let args: Vec<OsString> = iter.into_iter().skip(1).map(Into::into).collect();
+/*
+Tests: should succeed (✅) and fail (❌):
+```sh
+✅ ouch                                # show help
+✅ ouch --help                         # show help
+✅ ouch anything --help in here        # show help
+✅ ouch anything in here -h            # show help
+✅ ouch --version                      # show version
+✅ ouch --version anything             # show version
+✅ ouch anything -v here -h            # show version
+✅ ouch --version --help               # show help
+❌ ouch --h                            # invalid flag
+❌ ouch --v                            # invalid flag
+❌ ouch -help                          # invalid flag (-e -l -p)
+❌ ouch --any_other_flag               # invalid flag
+✅ ouch compress a b c output.zip      # Ok subcommand compress
+❌ ouch compress                       # Missing arguments
+❌ ouch compress anything              # Missing last argument
+✅ ouch --help compress anything       # show help
+✅ ouch compress --help                # show help
+✅ ouch anything -o anything           #   valid flag in this context
+❌ ouch compress anything -o anything  # invalid flag in this context
+❌ ouch anything -o                    # this flag requires   valid flag in this context
+```
 
-        // Says if any text matches any arg
-        let matches_any_arg = |texts: &[&str]| -> bool {
-            texts
-                .iter()
-                .any(|text| args.iter().find(|&arg| arg == text).is_some())
-        };
+Pending:
+ - Support `-y` and `-n`, as these options usage are not stabilized.
+*/
 
-        if matches_any_arg(&["--version", "-v"]) {
-            return Self::ShowVersion;
-        }
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
 
-        if matches_any_arg(&["--help", "-h"]) || args.is_empty() {
-            return Self::ShowHelp;
-        }
+    #[allow(unused_imports)]
+    use super::{try_arg_parsing, ArgParsingError, Command};
+    // util for test the argument parsing
+    macro_rules! test {
+        ($expected_command:expr, $input_text:expr) => {{
+            assert_eq!(
+                $expected_command,
+                try_arg_parsing($input_text.split_whitespace())
+            )
+        }};
+    }
 
-        let boolean_flags = vec![];
-        let positional_flags = vec![Flag::new("-o", "--output")];
+    #[test]
+    fn test_arg_parsing_help() {
+        let expected = Ok(Command::ShowHelp);
+        test!(expected, "ouch");
+        test!(expected, "ouch -h");
+        test!(expected, "ouch --help");
+        test!(expected, "ouch aaaaaaaa --help -o -e aaa");
+        test!(expected, "ouch aaaaaaaa -h");
+        test!(expected, "ouch --help compress aaaaaaaa");
+        test!(expected, "ouch compress --help");
+        test!(expected, "ouch --version --help");
+        test!(expected, "ouch aaaaaaaa -v aaaa -h");
+    }
 
-        let (args, flags) = filter_flags(args, boolean_flags, positional_flags);
+    #[test]
+    fn test_arg_parsing_version() {
+        let expected = Ok(Command::ShowVersion);
+        test!(expected, "ouch --version");
+        test!(expected, "ouch a --version b");
+        test!(expected, "ouch -v");
+        test!(expected, "ouch aaaa aaa -v asdasd");
+    }
 
-        // Safe: we checked for args.is_empty()
-        let first = &args[0];
+    // #[test]
+    // fn test_arg_parsing_invalid_flags() {
+    //     let expected = Err(ArgParsingError::InvalidFlags(vec![]));
+    //     test!(expected, "ouch -version");
+    // }
 
-        if first == "compress" {
-            let output_folder = flags.get(OsStr::new("--output")).map(PathBuf::from);
-            let files = args.into_iter().map(PathBuf::from).collect();
+    #[test]
+    fn test_arg_parsing_compress_subcommand() {
+        let files: Vec<PathBuf> = ["a", "b", "c"].iter().map(PathBuf::from).collect();
 
-            Command::Compress {
-                files,
-                output_folder,
-            }
-        } else {
-            if args.contains(&OsString::from("--output")) {
-                // Shouldn't be in here, this flag is only for the compress command
-                // return Command::UnexpectedFlag
-                // TODO: this is bad, fix it
-                return Command::UnknownFlags(vec!["--output".into()]);
-            }
+        let expected = Ok(Command::Compress {
+            files: files.clone(),
+            output_folder: None,
+        });
+        test!(expected, "ouch compress a b c");
 
-            let files = args.into_iter().map(PathBuf::from).collect();
-            Command::Decompress { files }
-        }
+        let expected = Ok(Command::Compress {
+            files: files.clone(),
+            output_folder: Some(PathBuf::from("folder")),
+        });
+        test!(expected, "ouch compress a b c --output folder");
+        test!(expected, "ouch compress a b --output folder c");
+        test!(expected, "ouch compress a --output folder b c");
+        test!(expected, "ouch compress --output folder a b c");
+    }
 
-        // let subcommands = ["decompress", "convert"];
-        // let subcommand_detected = subcommands
-        //     .iter()
-        //     .find(|&subcommand| subcommand == first)
-        //     .is_some();
+    #[test]
+    fn test_arg_parsing_decompress_subcommand() {
+        let files: Vec<PathBuf> = ["a", "b", "c"].iter().map(PathBuf::from).collect();
 
-        // // If there is no subcommand, defaults to subcommand "decompress"
-        // if !subcommand_detected {
-        //     args.insert(1, OsString::from("decompress"));
-        // }
+        let expected = Ok(Command::Decompress {
+            files: files.clone(),
+        });
+        test!(expected, "ouch a b c");
 
-        // // We guaranteed that
-        // let subcommand = args[0].to_str().unwrap();
+        let files: Vec<PathBuf> = ["a", "b", "c", "d"].iter().map(PathBuf::from).collect();
 
-        // if condition {
-        //     unimplemented!();
-        // }
-
-        // if matches() {
-        // unimplemented!();
-        // }
-
-        // We
-        //
-
-        // if matches(&args, &["--help", "-h"]) {
-        //     return Self::ShowHelp;
-        // }
-        // println!("{:?}", matches(&args, &["compress", "decompress"]));
-
-        // //
+        let expected = Ok(Command::Decompress {
+            files: files.clone(),
+        });
+        test!(expected, "ouch a b c d");
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -96,7 +96,7 @@ pub mod argparsing {
         {
             use std::os::windows::ffi::OsStrExt;
 
-            let iter = text.encode_wide();
+            let mut iter = text.encode_wide();
 
             // Note that hyphen_in_utf16 == 45_u16
             if let Some(45_u16) = iter.next() {

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -216,21 +216,22 @@ impl Evaluator {
     pub fn evaluate(command: Command) -> crate::Result<()> {
         // let output = command.output.clone();
 
-        match command {
-            Command::Compress {
-                files,
-                output_folder,
-            } => {
-                // Safe to unwrap since output is mandatory for compression
-                let output = output.unwrap();
-                Self::compress_files(files, output)?;
-            }
-            Command::Decompress(files_to_decompress) => {
-                for file in files_to_decompress {
-                    Self::decompress_file(file, &output)?;
-                }
-            }
-        }
-        Ok(())
+        todo!("fix this error");
+        // match command {
+        //     Command::Compress {
+        //         files,
+        //         output_folder,
+        //     } => {
+        //         // Safe to unwrap since output is mandatory for compression
+        //         let output = output.unwrap();
+        //         Self::compress_files(files, output)?;
+        //     }
+        //     Command::Decompress { files } => {
+        //         for file in files {
+        //             Self::decompress_file(file, &output)?;
+        //         }
+        //     }
+        // }
+        // Ok(())
     }
 }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -3,7 +3,7 @@ use std::{ffi::OsStr, fs, io::Write, path::PathBuf};
 use colored::Colorize;
 
 use crate::{
-    cli::{Command, CommandKind},
+    cli::Command,
     compressors::{
         BzipCompressor, Compressor, Entry, GzipCompressor, LzmaCompressor, TarCompressor,
         ZipCompressor,
@@ -214,15 +214,18 @@ impl Evaluator {
     }
 
     pub fn evaluate(command: Command) -> crate::Result<()> {
-        let output = command.output.clone();
+        // let output = command.output.clone();
 
-        match command.kind {
-            CommandKind::Compression(files_to_compress) => {
+        match command {
+            Command::Compress {
+                files,
+                output_folder,
+            } => {
                 // Safe to unwrap since output is mandatory for compression
                 let output = output.unwrap();
-                Self::compress_files(files_to_compress, output)?;
+                Self::compress_files(files, output)?;
             }
-            CommandKind::Decompression(files_to_decompress) => {
+            Command::Decompress(files_to_decompress) => {
                 for file in files_to_decompress {
                     Self::decompress_file(file, &output)?;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,19 +2,24 @@ mod cli;
 mod compressors;
 mod decompressors;
 mod error;
+#[allow(dead_code)]
 mod evaluator;
 mod extension;
 mod file;
 mod test;
 mod utils;
 
-use std::convert::TryFrom;
+#[allow(unreachable_code, unused_variables)]
+use std::env;
 
 use error::{Error, Result};
 use evaluator::Evaluator;
 
-fn main() -> crate::Result<()> {
-    let matches = cli::get_matches();
-    let command = cli::Command::try_from(matches)?;
-    Evaluator::evaluate(command)
+fn main() {
+    let command = cli::Command::from(env::args_os());
+    // match command {
+    //     Command::ShowHelp => {}
+    // }
+
+    // Evaluator::evaluate(command)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,26 @@
+#[allow(dead_code, unused_variables)]
 mod cli;
 mod compressors;
 mod decompressors;
 mod error;
-#[allow(dead_code)]
+#[allow(dead_code, unused_variables)]
 mod evaluator;
 mod extension;
 mod file;
 mod test;
 mod utils;
 
-#[allow(unreachable_code, unused_variables)]
-use std::env;
+use std::{env, result::Result as StdResult};
 
 use error::{Error, Result};
-use evaluator::Evaluator;
+// use evaluator::Evaluator;
 
-fn main() {
-    let command = cli::Command::from(env::args_os());
+fn main() -> StdResult<(), cli::ArgParsingError> {
+    let _command = cli::try_arg_parsing(env::args_os())?;
     // match command {
     //     Command::ShowHelp => {}
     // }
 
     // Evaluator::evaluate(command)
+    Ok(())
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,211 +1,211 @@
 // TODO: remove tests of CompressionFormat::try_from since that's no longer used anywhere
 
-#[cfg(test)]
-mod cli {
-    use std::{convert::TryFrom, fs, path::Path};
+// #[cfg(test)]
+// mod cli {
+//     use std::{convert::TryFrom, fs, path::Path};
 
-    use crate::{
-        cli::{clap_app, Command, CommandKind::*},
-        extension::{CompressionFormat::*, Extension},
-        file::File,
-    };
+//     use crate::{
+//         cli::{clap_app, Command, CommandKind::*},
+//         extension::{CompressionFormat::*, Extension},
+//         file::File,
+//     };
 
-    // ouch's command-line logic uses fs::canonicalize on its inputs so we cannot
-    // use made-up files for testing.
-    // make_dummy_file therefores creates a small temporary file to bypass fs::canonicalize errors
-    fn make_dummy_file<'a, P>(path: P) -> crate::Result<()>
-    where
-        P: AsRef<Path> + 'a,
-    {
-        fs::write(path.as_ref(), &[2, 3, 4, 5, 6, 7, 8, 9, 10])?;
-        Ok(())
-    }
+//     // ouch's command-line logic uses fs::canonicalize on its inputs so we cannot
+//     // use made-up files for testing.
+//     // make_dummy_file therefores creates a small temporary file to bypass fs::canonicalize errors
+//     fn make_dummy_file<'a, P>(path: P) -> crate::Result<()>
+//     where
+//         P: AsRef<Path> + 'a,
+//     {
+//         fs::write(path.as_ref(), &[2, 3, 4, 5, 6, 7, 8, 9, 10])?;
+//         Ok(())
+//     }
 
-    #[test]
-    fn decompress_files_into_folder() -> crate::Result<()> {
-        make_dummy_file("file.zip")?;
-        let matches = clap_app().get_matches_from(vec!["ouch", "-i", "file.zip", "-o", "folder/"]);
-        let command_from_matches = Command::try_from(matches)?;
+//     #[test]
+//     fn decompress_files_into_folder() -> crate::Result<()> {
+//         make_dummy_file("file.zip")?;
+//         let matches = clap_app().get_matches_from(vec!["ouch", "-i", "file.zip", "-o", "folder/"]);
+//         let command_from_matches = Command::try_from(matches)?;
 
-        assert_eq!(
-            command_from_matches,
-            Command {
-                kind: Decompression(vec![File {
-                    path: fs::canonicalize("file.zip")?,
-                    contents_in_memory: None,
-                    extension: Some(Extension::from(Zip))
-                }]),
-                output: Some(File {
-                    path: "folder".into(),
-                    contents_in_memory: None,
-                    extension: None
-                }),
-            }
-        );
+//         assert_eq!(
+//             command_from_matches,
+//             Command {
+//                 kind: Decompression(vec![File {
+//                     path: fs::canonicalize("file.zip")?,
+//                     contents_in_memory: None,
+//                     extension: Some(Extension::from(Zip))
+//                 }]),
+//                 output: Some(File {
+//                     path: "folder".into(),
+//                     contents_in_memory: None,
+//                     extension: None
+//                 }),
+//             }
+//         );
 
-        fs::remove_file("file.zip")?;
+//         fs::remove_file("file.zip")?;
 
-        Ok(())
-    }
+//         Ok(())
+//     }
 
-    #[test]
-    fn decompress_files() -> crate::Result<()> {
-        make_dummy_file("my-cool-file.zip")?;
-        make_dummy_file("file.tar")?;
-        let matches =
-            clap_app().get_matches_from(vec!["ouch", "-i", "my-cool-file.zip", "file.tar"]);
-        let command_from_matches = Command::try_from(matches)?;
+//     #[test]
+//     fn decompress_files() -> crate::Result<()> {
+//         make_dummy_file("my-cool-file.zip")?;
+//         make_dummy_file("file.tar")?;
+//         let matches =
+//             clap_app().get_matches_from(vec!["ouch", "-i", "my-cool-file.zip", "file.tar"]);
+//         let command_from_matches = Command::try_from(matches)?;
 
-        assert_eq!(
-            command_from_matches,
-            Command {
-                kind: Decompression(vec![
-                    File {
-                        path: fs::canonicalize("my-cool-file.zip")?,
-                        contents_in_memory: None,
-                        extension: Some(Extension::from(Zip))
-                    },
-                    File {
-                        path: fs::canonicalize("file.tar")?,
-                        contents_in_memory: None,
-                        extension: Some(Extension::from(Tar))
-                    }
-                ],),
-                output: None,
-            }
-        );
+//         assert_eq!(
+//             command_from_matches,
+//             Command {
+//                 kind: Decompression(vec![
+//                     File {
+//                         path: fs::canonicalize("my-cool-file.zip")?,
+//                         contents_in_memory: None,
+//                         extension: Some(Extension::from(Zip))
+//                     },
+//                     File {
+//                         path: fs::canonicalize("file.tar")?,
+//                         contents_in_memory: None,
+//                         extension: Some(Extension::from(Tar))
+//                     }
+//                 ],),
+//                 output: None,
+//             }
+//         );
 
-        fs::remove_file("my-cool-file.zip")?;
-        fs::remove_file("file.tar")?;
+//         fs::remove_file("my-cool-file.zip")?;
+//         fs::remove_file("file.tar")?;
 
-        Ok(())
-    }
+//         Ok(())
+//     }
 
-    #[test]
-    fn compress_files() -> crate::Result<()> {
-        make_dummy_file("file")?;
-        make_dummy_file("file2.jpeg")?;
-        make_dummy_file("file3.ok")?;
+//     #[test]
+//     fn compress_files() -> crate::Result<()> {
+//         make_dummy_file("file")?;
+//         make_dummy_file("file2.jpeg")?;
+//         make_dummy_file("file3.ok")?;
 
-        let matches = clap_app().get_matches_from(vec![
-            "ouch",
-            "-i",
-            "file",
-            "file2.jpeg",
-            "file3.ok",
-            "-o",
-            "file.tar",
-        ]);
-        let command_from_matches = Command::try_from(matches)?;
+//         let matches = clap_app().get_matches_from(vec![
+//             "ouch",
+//             "-i",
+//             "file",
+//             "file2.jpeg",
+//             "file3.ok",
+//             "-o",
+//             "file.tar",
+//         ]);
+//         let command_from_matches = Command::try_from(matches)?;
 
-        assert_eq!(
-            command_from_matches,
-            Command {
-                kind: Compression(vec![
-                    fs::canonicalize("file")?,
-                    fs::canonicalize("file2.jpeg")?,
-                    fs::canonicalize("file3.ok")?
-                ]),
-                output: Some(File {
-                    path: "file.tar".into(),
-                    contents_in_memory: None,
-                    extension: Some(Extension::from(Tar))
-                }),
-            }
-        );
+//         assert_eq!(
+//             command_from_matches,
+//             Command {
+//                 kind: Compression(vec![
+//                     fs::canonicalize("file")?,
+//                     fs::canonicalize("file2.jpeg")?,
+//                     fs::canonicalize("file3.ok")?
+//                 ]),
+//                 output: Some(File {
+//                     path: "file.tar".into(),
+//                     contents_in_memory: None,
+//                     extension: Some(Extension::from(Tar))
+//                 }),
+//             }
+//         );
 
-        fs::remove_file("file")?;
-        fs::remove_file("file2.jpeg")?;
-        fs::remove_file("file3.ok")?;
+//         fs::remove_file("file")?;
+//         fs::remove_file("file2.jpeg")?;
+//         fs::remove_file("file3.ok")?;
 
-        Ok(())
-    }
-}
+//         Ok(())
+//     }
+// }
 
-#[cfg(test)]
-mod cli_errors {
+// #[cfg(test)]
+// mod cli_errors {
 
-    use std::convert::TryFrom;
+//     use std::convert::TryFrom;
 
-    use crate::cli::{clap_app, Command};
+//     use crate::cli::{clap_app, Command};
 
-    #[test]
-    fn compress_files() -> crate::Result<()> {
-        let matches =
-            clap_app().get_matches_from(vec!["ouch", "-i", "a_file", "file2.jpeg", "file3.ok"]);
-        let res = Command::try_from(matches);
+//     #[test]
+//     fn compress_files() -> crate::Result<()> {
+//         let matches =
+//             clap_app().get_matches_from(vec!["ouch", "-i", "a_file", "file2.jpeg", "file3.ok"]);
+//         let res = Command::try_from(matches);
 
-        assert_eq!(
-            res,
-            Err(crate::Error::InputsMustHaveBeenDecompressible(
-                "a_file".into()
-            ))
-        );
+//         assert_eq!(
+//             res,
+//             Err(crate::Error::InputsMustHaveBeenDecompressible(
+//                 "a_file".into()
+//             ))
+//         );
 
-        Ok(())
-    }
-}
+//         Ok(())
+//     }
+// }
 
-#[cfg(test)]
-mod extension_extraction {
-    use std::convert::TryFrom;
+// #[cfg(test)]
+// mod extension_extraction {
+//     use std::convert::TryFrom;
 
-    use crate::extension::{CompressionFormat, Extension};
+//     use crate::extension::{CompressionFormat, Extension};
 
-    #[test]
-    fn test_extension_zip() {
-        let path = "filename.tar.zip";
-        assert_eq!(
-            CompressionFormat::try_from(path),
-            Ok(CompressionFormat::Zip)
-        );
-    }
+//     #[test]
+//     fn test_extension_zip() {
+//         let path = "filename.tar.zip";
+//         assert_eq!(
+//             CompressionFormat::try_from(path),
+//             Ok(CompressionFormat::Zip)
+//         );
+//     }
 
-    #[test]
-    fn test_extension_tar_gz() {
-        let extension = Extension::new("folder.tar.gz").unwrap();
-        assert_eq!(
-            extension,
-            Extension {
-                first_ext: Some(CompressionFormat::Tar),
-                second_ext: CompressionFormat::Gzip
-            }
-        );
-    }
+//     #[test]
+//     fn test_extension_tar_gz() {
+//         let extension = Extension::new("folder.tar.gz").unwrap();
+//         assert_eq!(
+//             extension,
+//             Extension {
+//                 first_ext: Some(CompressionFormat::Tar),
+//                 second_ext: CompressionFormat::Gzip
+//             }
+//         );
+//     }
 
-    #[test]
-    fn test_extension_tar() {
-        let path = "pictures.tar";
-        assert_eq!(
-            CompressionFormat::try_from(path),
-            Ok(CompressionFormat::Tar)
-        );
-    }
+//     #[test]
+//     fn test_extension_tar() {
+//         let path = "pictures.tar";
+//         assert_eq!(
+//             CompressionFormat::try_from(path),
+//             Ok(CompressionFormat::Tar)
+//         );
+//     }
 
-    #[test]
-    fn test_extension_gz() {
-        let path = "passwords.tar.gz";
-        assert_eq!(
-            CompressionFormat::try_from(path),
-            Ok(CompressionFormat::Gzip)
-        );
-    }
+//     #[test]
+//     fn test_extension_gz() {
+//         let path = "passwords.tar.gz";
+//         assert_eq!(
+//             CompressionFormat::try_from(path),
+//             Ok(CompressionFormat::Gzip)
+//         );
+//     }
 
-    #[test]
-    fn test_extension_lzma() {
-        let path = "mygame.tar.lzma";
-        assert_eq!(
-            CompressionFormat::try_from(path),
-            Ok(CompressionFormat::Lzma)
-        );
-    }
+//     #[test]
+//     fn test_extension_lzma() {
+//         let path = "mygame.tar.lzma";
+//         assert_eq!(
+//             CompressionFormat::try_from(path),
+//             Ok(CompressionFormat::Lzma)
+//         );
+//     }
 
-    #[test]
-    fn test_extension_bz() {
-        let path = "songs.tar.bz";
-        assert_eq!(
-            CompressionFormat::try_from(path),
-            Ok(CompressionFormat::Bzip)
-        );
-    }
-}
+//     #[test]
+//     fn test_extension_bz() {
+//         let path = "songs.tar.bz";
+//         assert_eq!(
+//             CompressionFormat::try_from(path),
+//             Ok(CompressionFormat::Bzip)
+//         );
+//     }
+// }


### PR DESCRIPTION
Tests: should succeed (✅) and fail (❌):
```sh
✅ ouch                                # show help
✅ ouch --help                         # show help
✅ ouch anything --help in here        # show help
✅ ouch anything in here -h            # show help
✅ ouch --version                      # show version
✅ ouch --version anything             # show version
✅ ouch anything -v here -h            # show version
✅ ouch --version --help               # show help
❌ ouch --h                            # invalid flag
❌ ouch --v                            # invalid flag
❌ ouch -help                          # invalid flag (-e -l -p)
❌ ouch --any_other_flag               # invalid flag
✅ ouch compress a b c output.zip      # Ok subcommand compress
❌ ouch compress                       # Missing arguments
❌ ouch compress anything              # Missing last argument
✅ ouch --help compress anything       # show help
✅ ouch compress --help                # show help
✅ ouch anything -o anything           #   valid flag in this context
❌ ouch compress anything -o anything  # invalid flag in this context
❌ ouch anything -o                    # this positional flag requires another argument
```

Pending:
 - Support `-y` and `-n`, as these options usage are not stabilized.